### PR TITLE
Use post process hook

### DIFF
--- a/Classes/Agents/PageMovedAgent.php
+++ b/Classes/Agents/PageMovedAgent.php
@@ -1,11 +1,9 @@
 <?php
 
-namespace Pluswerk\Project\Agents;
+namespace Pluswerk\CacheAutomation\Agents;
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 use TYPO3\CMS\Core\Database\QueryGenerator;
-use \Pluswerk\CacheAutomation\Agents\AbstractAgent;
 
 class PageMovedAgent extends AbstractAgent
 {

--- a/Classes/Agents/PageMovedAgent.php
+++ b/Classes/Agents/PageMovedAgent.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Pluswerk\Project\Agents;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
+use TYPO3\CMS\Core\Database\QueryGenerator;
+use \Pluswerk\CacheAutomation\Agents\AbstractAgent;
+
+class PageMovedAgent extends AbstractAgent
+{
+    public function getExpiredPages(string $table, $uid, array $agentConfiguration, array $changedFields): array
+    {
+        $pagesUidList = [];
+        if ($table === 'pages') {
+            if ($this->pageMovedInTree($changedFields)) {
+                $queryGenerator = GeneralUtility::makeInstance(QueryGenerator::class);
+                $pages = $queryGenerator->getTreeList($uid, 99, 0, 1);
+                $pagesUidList = array_merge($pagesUidList, explode(',', $pages));
+            }
+        }
+
+        return $pagesUidList;
+    }
+
+    /**
+     * Returns true, if the page was moved via the page tree
+     *
+     * @param array $changedFields
+     * @return bool
+     */
+    protected function pageMovedInTree(array $changedFields): bool
+    {
+        return array_keys($changedFields) === ['uid'];
+    }
+}

--- a/Classes/Hook/DataHandlerDetector.php
+++ b/Classes/Hook/DataHandlerDetector.php
@@ -58,7 +58,32 @@ class DataHandlerDetector implements SingletonInterface
      */
     public function processDatamap_afterDatabaseOperations($status, string $table, $id, array $changedFields, DataHandler $dataHandler)
     {
-        // @codingStandardsIgnoreEnd
+        $this->clearCachedPagesFoundByAgents($table, $id, $changedFields);
+
+    }
+
+    /**
+     * @param string $status The status of the record
+     * @param string $table Database table name
+     * @param int|string $id The uid of the record or something like "NEW59785a1ec52" if the record is new
+     * @param int $pageIdentifier The id of the page
+     * @throws \Exception
+     */
+    public function processCmdmap_postProcess($status, $table, $id, $pageIdentifier)
+    {
+        $this->clearCachedPagesFoundByAgents($table, $id, ['uid' => $pageIdentifier]);
+
+    }
+
+    /**
+     * @param string $table
+     * @param $id
+     * @param array $changedFields of an array containing just the uid of a page
+     * @throws \Exception
+     */
+    protected function clearCachedPagesFoundByAgents(string $table, $id, array $changedFields)
+    {
+// @codingStandardsIgnoreEnd
         $expiredPages = [];
         if ($this->configuration->isConfigured($table)) {
             $agentConfigurations = $this->configuration->getAgentsForTable($table);

--- a/Classes/Hook/DataHandlerDetector.php
+++ b/Classes/Hook/DataHandlerDetector.php
@@ -99,7 +99,13 @@ class DataHandlerDetector implements SingletonInterface
         }
 
         if (count($expiredPages) !== 0) {
-            $this->cacheService->clearPageCache(array_unique($expiredPages));
+            $expiredPages = array_unique($expiredPages);
+            // TODO: use new API in TYPO3 V9
+            $extensionConfiguration = $extensionConfiguration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cache_automation']);
+            $arrayChunks = array_chunk($expiredPages, $extensionConfiguration['numberOfCachedPagesToClear']);
+            foreach ($arrayChunks as $singleChunk) {
+                $this->cacheService->clearPageCache($singleChunk);
+            }
         }
     }
 }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,2 @@
+# cat=basic/enable; type=string; label=Number of cached pages that will be cleared in one chunk
+numberOfCachedPagesToClear =


### PR DESCRIPTION
The postprocess hook is registered but not used. This commit implements the corresponding function and adds an example agent. The agent is triggered if a page is moved via DnD in the page tree. It deletes the caches of the child pages of the moved page.