### PR TITLE
[CLEANUP] conmpatibel for typo3 10.4.*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - 8.0
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ git:
   depth: 5
 
 php:
-  - 7.1
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
 
 cache:
   directories:

--- a/Classes/Hook/DataHandlerDetector.php
+++ b/Classes/Hook/DataHandlerDetector.php
@@ -57,7 +57,7 @@ class DataHandlerDetector implements SingletonInterface
      * @param DataHandler $dataHandler Reference back to the DataHandler
      * @throws \RuntimeException
      */
-    // phpcs:ignore
+    // @phpcs:ignore PSR1.Methods.CamelCapsMethodName
     public function processDatamap_afterDatabaseOperations(/** @noinspection PhpUnusedParameterInspection */ string $status, string $table, $id, array $changedFields, DataHandler $dataHandler): void
     {
         $expiredPages = [];

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   },
   "license": "GPL-3.0+",
   "require": {
-    "typo3/cms-core": ">=8.7 <9.6",
+    "typo3/cms-core": ">=8.7 <10.4",
     "php": ">=7.1"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "license": "GPL-3.0+",
   "require": {
     "typo3/cms-core": ">=8.7 <10.4",
-    "php": ">=7.1"
+    "php": ">=7.2"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     }
   },
   "replace": {
-    "cache_automation": "self.version",
+    "pluswerk/cache_automation": "self.version",
     "typo3-ter/cache_automation": "self.version",
     "typo3-ter/cache-automation": "self.version"
   },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "typo3-ter/cache-automation": "self.version"
   },
   "require-dev": {
-    "pluswerk/grumphp-config": "2.*"
+    "pluswerk/grumphp-config": "4.*"
   },
   "extra": {
     "pluswerk/grumphp-config": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,6 +1,7 @@
 <?php
 
-$EM_CONF['cache_automation'] = [
+// @phpstan-ignore-next-line
+$EM_CONF[$_EXTKEY] = [
     'title' => '+Pluswerk: Cache Automation',
     'description' => 'The extension clear caches with some magic automated in the right moment',
     'category' => 'be',

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,5 +1,6 @@
 <?php
-$EM_CONF[$_EXTKEY] = [
+
+$EM_CONF['cache_automation'] = [
     'title' => '+Pluswerk: Cache Automation',
     'description' => 'The extension clear caches with some magic automated in the right moment',
     'category' => 'be',

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -17,7 +17,7 @@ $EM_CONF['cache_automation'] = [
     'version' => '1.2.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '8.7.0-9.5.99',
+            'typo3' => '8.7.0-10.4.99',
         ],
         'conflicts' => [],
     ],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,4 +1,5 @@
 <?php
+
 /***
  * This file is part of an +Pluswerk AG Extension for TYPO3 CMS.
  *
@@ -12,7 +13,7 @@ if (!defined('TYPO3_MODE')) {
     die('Access denied.');
 }
 
-call_user_func(function () use ($_EXTKEY) {
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass'][$_EXTKEY] = \Pluswerk\CacheAutomation\Hook\DataHandlerDetector::class;
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][$_EXTKEY] = \Pluswerk\CacheAutomation\Hook\DataHandlerDetector::class;
+call_user_func(function () {
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass']['cache_automation'] = \Pluswerk\CacheAutomation\Hook\DataHandlerDetector::class;
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass']['cache_automation'] = \Pluswerk\CacheAutomation\Hook\DataHandlerDetector::class;
 });


### PR DESCRIPTION
emptying cache tested: with and without addAgentForTables() loaded,  and changed a data enty and then chcked the list view, which is rendered with and without empted cache in FE.